### PR TITLE
Add command-line tools for database init and CSV import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,22 @@ with Session() as session:
 
 The call to `get_session_maker` automatically creates the database tables if
 needed.
+
+## Command line interface
+
+The package installs a small CLI named `hvp-db`.
+
+Initialize a new SQLite database:
+
+```bash
+hvp-db init sqlite:///hvp.db
+```
+
+Load samples from a CSV file:
+
+```bash
+hvp-db load-csv sqlite:///hvp.db samples.csv
+```
+
+CSV columns should match the fields of the `Sample` model and dates must be in
+ISO format (`YYYY-MM-DD`).

--- a/hvp_db/__main__.py
+++ b/hvp_db/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    main()

--- a/hvp_db/cli.py
+++ b/hvp_db/cli.py
@@ -1,0 +1,60 @@
+import argparse
+import csv
+from datetime import date
+from typing import Dict
+
+from sqlalchemy import Date
+
+from .models import Sample, get_session_maker, init_engine
+
+
+def _convert_row(row: Dict[str, str]) -> Dict[str, object]:
+    """Convert CSV string values to appropriate Python types."""
+    columns = {c.name: c.type for c in Sample.__table__.columns}
+    data: Dict[str, object] = {}
+    for key, value in row.items():
+        if value in (None, ""):
+            continue
+        col_type = columns.get(key)
+        if isinstance(col_type, Date):
+            data[key] = date.fromisoformat(value)
+        else:
+            data[key] = value
+    return data
+
+
+def _load_csv(url: str, csv_path: str, *, echo: bool = False) -> None:
+    """Load ``Sample`` rows from a CSV file into the database."""
+    Session = get_session_maker(url, echo=echo)
+    with open(csv_path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        with Session() as session:
+            for row in reader:
+                sample = Sample(**_convert_row(row))
+                session.add(sample)
+            session.commit()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="hvp-db")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_init = subparsers.add_parser("init", help="initialize a new database")
+    p_init.add_argument("url", help="database URL, e.g. sqlite:///hvp.db")
+    p_init.add_argument("--echo", action="store_true", help="echo SQL statements")
+
+    p_load = subparsers.add_parser("load-csv", help="load sample rows from a CSV file")
+    p_load.add_argument("url", help="database URL")
+    p_load.add_argument("csvfile", help="path to CSV file")
+    p_load.add_argument("--echo", action="store_true", help="echo SQL statements")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init":
+        init_engine(args.url, echo=args.echo)
+    elif args.command == "load-csv":
+        _load_csv(args.url, args.csvfile, echo=args.echo)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ requires-python = ">=3.8"
 dependencies = [
     "SQLAlchemy>=2.0.43"
 ]
+
+[project.scripts]
+hvp-db = "hvp_db.cli:main"


### PR DESCRIPTION
## Summary
- add `hvp-db` CLI with `init` and `load-csv` subcommands
- expose CLI as executable via project scripts
- document new CLI usage in README

## Testing
- `python -m hvp_db.cli --help`
- `python -m hvp_db.cli init sqlite:////tmp/hvp.db`
- `python -m hvp_db.cli load-csv sqlite:////tmp/hvp.db sample.csv`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68ba333ab4188323ab8b0209be777ead