### PR TITLE
Fail load command on invalid enum values

### DIFF
--- a/hvp_db/cli.py
+++ b/hvp_db/cli.py
@@ -3,35 +3,70 @@ import csv
 from datetime import date
 from hvp_db.app import main as run_web_app
 from hvp_db.models import Sample, get_session_maker, init_engine
-from sqlalchemy import Date
+from sqlalchemy import Date, Enum
 from typing import Dict
 
 
-def _convert_row(row: Dict[str, str]) -> Dict[str, object]:
-    """Convert CSV string values to appropriate Python types."""
+def _convert_row(row: Dict[str, str]) -> tuple[Dict[str, object], list[str]]:
+    """Convert CSV string values to appropriate Python types.
+
+    Returns a tuple of the converted row data and a list of validation errors
+    encountered.  Errors are reported rather than raised so that all issues in a
+    file can be collected and reported together.
+    """
+
     columns = {c.name: c.type for c in Sample.__table__.columns}
     data: Dict[str, object] = {}
+    errors: list[str] = []
+
     for key, value in row.items():
         if value in (None, ""):
             continue
+
         col_type = columns.get(key)
         if isinstance(col_type, Date):
-            data[key] = date.fromisoformat(value)
+            try:
+                data[key] = date.fromisoformat(value)
+            except ValueError:
+                errors.append(f"{key}: invalid date {value!r}")
+        elif isinstance(col_type, Enum):
+            if value not in col_type.enums:
+                allowed = ", ".join(col_type.enums)
+                errors.append(f"{key}: {value!r} is not one of {allowed}")
+            else:
+                data[key] = value
         else:
             data[key] = value
-    return data
+
+    return data, errors
 
 
 def _load_csv(url: str, csv_path: str, *, echo: bool = False) -> None:
-    """Load ``Sample`` rows from a CSV file into the database."""
+    """Load ``Sample`` rows from a CSV file into the database.
+
+    The CSV file is fully validated before any rows are written.  If invalid
+    values are encountered (e.g. for enumerated fields) a :class:`ValueError`
+    is raised summarizing all issues.
+    """
+
     Session = get_session_maker(url, echo=echo)
     with open(csv_path, newline="") as fh:
         reader = csv.DictReader(fh)
-        with Session() as session:
-            for row in reader:
-                sample = Sample(**_convert_row(row))
-                session.add(sample)
-            session.commit()
+        errors: list[str] = []
+        samples: list[Sample] = []
+        for lineno, row in enumerate(reader, start=2):
+            data, row_errors = _convert_row(row)
+            if row_errors:
+                errors.append(f"line {lineno}: " + "; ".join(row_errors))
+            else:
+                samples.append(Sample(**data))
+
+        if errors:
+            raise ValueError("Invalid data encountered\n" + "\n".join(errors))
+
+    with Session() as session:
+        session.add_all(samples)
+        session.commit()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -56,7 +91,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.command == "init":
         init_engine(args.url, echo=args.echo)
     elif args.command == "load":
-        _load_csv(args.url, args.csvfile, echo=args.echo)
+        try:
+            _load_csv(args.url, args.csvfile, echo=args.echo)
+        except ValueError as exc:
+            parser.error(str(exc))
     elif args.command == "web":
         run_web_app(args.url, args.password)
     else:

--- a/tests/test_cli_load.py
+++ b/tests/test_cli_load.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from hvp_db.cli import _load_csv
+
+
+def test_load_csv_reports_all_enum_errors(tmp_path):
+    csv_content = (
+        "sample_id,participant_id,anatomical_site,storage_buffer,sample_use\n"
+        "s1,p1,invalid_site,neat,experiment\n"
+        "s2,p2,np_swab,invalid_buffer,invalid_use\n"
+    )
+    csv_file = tmp_path / "samples.csv"
+    csv_file.write_text(csv_content)
+
+    with pytest.raises(ValueError) as exc:
+        _load_csv("sqlite:///:memory:", str(csv_file))
+
+    message = str(exc.value)
+    assert "line 2" in message and "anatomical_site" in message
+    assert "line 3" in message and "storage_buffer" in message
+    assert "sample_use" in message


### PR DESCRIPTION
## Summary
- validate CSV rows against enum definitions when loading
- aggregate all load errors and abort instead of committing
- test that all invalid enum values are reported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0536708108323b09a47d5a0cbc34d