### PR TITLE
Fix samples API response for DataTables

### DIFF
--- a/hvp_db/app.py
+++ b/hvp_db/app.py
@@ -80,7 +80,7 @@ def create_app(
             samples_data = []
             for sample in session.scalars(select(Sample)).all():
                 samples_data.append({col: getattr(sample, col) for col in columns})
-        return jsonify(samples_data)
+        return jsonify({"data": samples_data})
 
     return app
 


### PR DESCRIPTION
## Summary
- Return samples data under a `data` key so DataTables can read it without errors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0584f5d1c83238d511f3e41045439