### PR TITLE
Adjust banner styling

### DIFF
--- a/hvp_db/templates/base.html
+++ b/hvp_db/templates/base.html
@@ -19,7 +19,7 @@
     }
 
     .site-banner {
-      background-color: #ffffff;
+      background-color: #9ca3af;
       border-bottom: 1px solid #e5e7eb;
       padding: 0.75rem 1.5rem;
       box-shadow: 0 1px 2px rgba(15, 23, 42, 0.1);
@@ -28,9 +28,15 @@
     .banner-content {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: flex-start;
+      gap: 1.5rem;
       max-width: 960px;
       margin: 0 auto;
+    }
+
+    .banner-nav {
+      display: flex;
+      align-items: center;
     }
 
     .logo-link img {


### PR DESCRIPTION
## Summary
- change the banner background to a medium gray tone
- align the logo icon and navigation link to the left side of the banner with consistent spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daddccf8808323bde207ea70c61286