### PR TITLE
Adjust navigation to reflect authentication state

### DIFF
--- a/hvp_db/templates/base.html
+++ b/hvp_db/templates/base.html
@@ -28,15 +28,22 @@
     .banner-content {
       display: flex;
       align-items: center;
-      justify-content: flex-start;
+      justify-content: space-between;
       gap: 1.5rem;
       max-width: 960px;
       margin: 0 auto;
     }
 
+    .banner-left {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
     .banner-nav {
       display: flex;
       align-items: center;
+      gap: 1rem;
     }
 
     .logo-link img {
@@ -45,16 +52,34 @@
       display: block;
     }
 
-    .banner-nav a {
+    .banner-nav a,
+    .auth-button {
       color: #0f172a;
       font-weight: 600;
       text-decoration: none;
       font-size: 1rem;
+      padding: 0.5rem 1rem;
+      border-radius: 9999px;
+    }
+
+    .auth-button {
+      border: 1px solid #0f172a;
+      transition: background-color 0.2s ease, color 0.2s ease;
     }
 
     .banner-nav a:hover,
-    .banner-nav a:focus {
-      text-decoration: underline;
+    .banner-nav a:focus,
+    .auth-button:hover,
+    .auth-button:focus {
+      text-decoration: none;
+      background-color: #0f172a;
+      color: #f9fafb;
+    }
+
+    .banner-actions {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
     }
 
     .site-main {
@@ -67,12 +92,23 @@
 <body>
   <header class="site-banner">
     <div class="banner-content">
-      <a class="logo-link" href="{{ url_for('hvp.index') }}">
-        <img src="{{ url_for('static', filename='HVP_logo.svg') }}" alt="Human Virome Project logo">
-      </a>
-      <nav class="banner-nav">
-        <a href="{{ url_for('hvp.samples') }}">Samples</a>
-      </nav>
+      <div class="banner-left">
+        <a class="logo-link" href="{{ url_for('hvp.index') }}">
+          <img src="{{ url_for('static', filename='HVP_logo.svg') }}" alt="Human Virome Project logo">
+        </a>
+        {% if session.get("authenticated") %}
+        <nav class="banner-nav">
+          <a href="{{ url_for('hvp.samples') }}">Samples</a>
+        </nav>
+        {% endif %}
+      </div>
+      <div class="banner-actions">
+        {% if session.get("authenticated") %}
+        <a class="auth-button" href="{{ url_for('hvp.logout') }}">Logout</a>
+        {% else %}
+        <a class="auth-button" href="{{ url_for('hvp.login') }}">Login</a>
+        {% endif %}
+      </div>
     </div>
   </header>
   <main class="site-main">


### PR DESCRIPTION
## Summary
- hide navigation links unless the session is authenticated and show a login button when logged out
- show navigation links together with a logout button for authenticated users and restyle the header layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae0d0cb208323a5853a2ffdb432ab