### PR TITLE
Fix samples column filters when table is scrolled

### DIFF
--- a/hvp_db/templates/samples.html
+++ b/hvp_db/templates/samples.html
@@ -174,9 +174,15 @@
       deferRender: true
     });
 
-    $('#samples-table thead tr.filter-row input').on('keyup change', function() {
+    const $tableContainer = $(table.table().container());
+    $tableContainer.on('keyup change input', 'thead tr.filter-row input', function() {
       const columnIndex = $(this).data('column-index');
-      table.column(columnIndex).search(this.value).draw();
+      const column = table.column(columnIndex);
+      const value = this.value;
+
+      if (column.search() !== value) {
+        column.search(value).draw();
+      }
     });
 
     const $columnToggleGrid = $('#column-toggle-grid');


### PR DESCRIPTION
## Summary
- delegate filter input events through the DataTables container so cloned headers receive them
- avoid redundant draws by skipping searches when the value has not changed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae3c24f788323bc5465095eab3cdd