### PR TITLE
Fix static asset URLs for nginx deployment

### DIFF
--- a/hvp_db/app.py
+++ b/hvp_db/app.py
@@ -20,7 +20,7 @@ def create_app(
         Password required to log in. If not provided, it will be read from
         the environment variable `HVP_DB_PASSWORD`
     """
-    app = Flask(__name__)
+    app = Flask(__name__, static_url_path="/hvp/static")
     app.secret_key = uuid.uuid4().hex
     if shared_password is None:
         shared_password = os.environ.get("HVP_DB_PASSWORD")


### PR DESCRIPTION
## Summary
- configure the Flask app to serve static files from /hvp/static so assets resolve when deployed under /hvp/

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae6ae60988323a3f5a9b5ca62fb95