### PR TITLE
Fix samples table alignment and enforce sample ID visibility

### DIFF
--- a/hvp_db/templates/samples.html
+++ b/hvp_db/templates/samples.html
@@ -92,7 +92,11 @@
 <script>
   const columns = {{ columns | tojson }};
   const dateColumns = {{ date_columns | tojson }};
+  const alwaysVisibleColumns = new Set([
+    'sample_id'
+  ]);
   const defaultVisibleColumns = new Set([
+    'sample_id',
     'sample_id_alias',
     'participant_id',
     'anatomical_site',
@@ -102,7 +106,7 @@
     'extraction_type',
     'sequence_run_id'
   ]);
-  const stickyColumnName = 'sample_id_alias';
+  const stickyColumnName = 'sample_id';
 
   function formatDateValue(value) {
     if (!value) {
@@ -154,7 +158,7 @@
       columns: columns.map(col => ({
         data: col,
         title: col,
-        visible: defaultVisibleColumns.has(col)
+        visible: defaultVisibleColumns.has(col) || alwaysVisibleColumns.has(col)
       })),
       columnDefs: columnDefs,
       dom: 'Bfrtip',
@@ -188,12 +192,14 @@
     const $columnToggleGrid = $('#column-toggle-grid');
     columns.forEach(function(columnName, index) {
       const id = `column-toggle-${index}`;
-      const isChecked = defaultVisibleColumns.has(columnName);
+      const isRequired = alwaysVisibleColumns.has(columnName);
+      const isChecked = isRequired || defaultVisibleColumns.has(columnName);
       const $checkbox = $('<input>', {
         type: 'checkbox',
         id,
         checked: isChecked,
-        'data-column-index': index
+        'data-column-index': index,
+        disabled: isRequired
       });
 
       const $label = $('<label>', { for: id });
@@ -205,6 +211,15 @@
       const columnIndex = $(this).data('column-index');
       const column = table.column(columnIndex);
       column.visible(this.checked);
+      table.columns.adjust().draw(false);
+    });
+
+    table.on('column-visibility.dt draw.dt', function() {
+      table.columns.adjust();
+    });
+
+    $(window).on('resize', function() {
+      table.columns.adjust();
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- adjust the samples DataTable so column sizing is recalculated after draws, visibility changes, and resizes to keep headers aligned with data
- require the sample_id column to stay visible, disable its toggle, and pin it as the sticky column instead of sample_id_alias
- keep the sample_id column included in the default visible set alongside other commonly used columns

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68dae8cd3f2483238e6dcc5871fa7602